### PR TITLE
Add b'\\' and b']' to USERINFO encode set

### DIFF
--- a/src/encode_sets.rs
+++ b/src/encode_sets.rs
@@ -14,6 +14,8 @@ pub(crate) const USERINFO: &AsciiSet = &PATH
     .add(b'=')
     .add(b'@')
     .add(b'[')
+    .add(b'\\')
+    .add(b']')
     .add(b'^')
     .add(b'|');
 pub(crate) const COMPONENT: &AsciiSet = &USERINFO.add(b'$').add(b'&').add(b'+').add(b',');


### PR DESCRIPTION
According to https://url.spec.whatwg.org/#userinfo-percent-encode-set, those characters are part of the encode set